### PR TITLE
App Submitted - spacy-wrapper.v1

### DIFF
--- a/docs/spacy-wrapper/v1/index.md
+++ b/docs/spacy-wrapper/v1/index.md
@@ -5,7 +5,6 @@
 * App ID: [https://apps.clams.ai/spacy-wrapper/v1](https://apps.clams.ai/spacy-wrapper/v1)
 * App License: Apache 2.0
 * Source Repository: [https://github.com/clamsproject/app-spacy-nlp](https://github.com/clamsproject/app-spacy-nlp)
-* Prebuilt Container Image: [ghcr.io/clamsproject/app-spacy-wrapper:v1](ghcr.io/clamsproject/app-spacy-wrapper:v1)
 * Analyzer Version: 3.1.2
 * Analyzer License: MIT
 


### PR DESCRIPTION
( closes \#84 .)
This PR registers the app spacy-wrapper.v1 from https://github.com/clamsproject/app-spacy-wrapper/releases/tag/v1. Carefully review the metadata before merging. If something is wrong with the metadata, please close the PR and let the app developer know.